### PR TITLE
Require path >= 17.0

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,13 +5,14 @@ Changelog
 3.4.0a3+slc1 (unreleased)
 -------------------------
 
-- Nothing changed yet.
+- Require path>= 17.0
+  [gyst]
 
 
 3.4.0a3+slc0 (2025-08-13)
 -------------------------
 
-- Use Path 0.17
+- Use path 17.0
   [ale-rt]
 
 

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(name='ftw.upgrade',
       install_requires=[
         'argcomplete',
         'inflection',
-        'path.py >= 6.2',
+        'path >= 17.0',
         'requests',
         'setuptools',
         'six >= 1.12.0',


### PR DESCRIPTION
This breaks on path 16.x.